### PR TITLE
fix: shouldn't call a dispatch source's cancel when all you need is to suspend the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ You can request this entitlement by sending an email to networkextension@apple.c
 The SimpleTunnel iOS products require iOS 9.0 or newer.
 The SimpleTunnel OS X products require OS X 11.0 or newer.
 
+### Build
+
+SimpleTunnel requires Xcode 8.0 or newer.
+The SimpleTunnel iOS targets require the iOS 9.0 SDK or newer.
+The SimpleTunnel OS X targets require the OS X 11.0 SDK or newer.
+
+Copyright (C) 2016 Apple Inc. All rights reserved.
+
+# Changes 
+
+There are a couple of changes done to the orignal demo project published by Apple to get this working. 
+
+- codebase upgraded to use the latest API
+- codebase make compatible with the latest swift version (5.2)
+- serveral bugfixes 
+
 ### Tunnel Server 
 
 The tunnel server command line program needs to be run as "root" and pass in the config file and port number as arguments. 
@@ -63,10 +79,5 @@ The info.plist of PacketTunnel network extension is edited to add the following 
 </array>
 ```
 
-### Build
-
-SimpleTunnel requires Xcode 8.0 or newer.
-The SimpleTunnel iOS targets require the iOS 9.0 SDK or newer.
-The SimpleTunnel OS X targets require the OS X 11.0 SDK or newer.
-
-Copyright (C) 2016 Apple Inc. All rights reserved.
+### Bugfix 
+- [shouldn't call cancel on a dispatch source](https://github.com/Alex1989Wang/SimpleTunnel-Apple/pull/3)

--- a/tunnel_server1/ServerTunnel.swift
+++ b/tunnel_server1/ServerTunnel.swift
@@ -21,7 +21,6 @@ class ServerTunnel: Tunnel, TunnelDelegate, StreamDelegate {
     var writeStream: OutputStream?
 
 	/// A buffer where the data for the current packet is accumulated.
-//	let packetBuffer = NSMutableData()
     private(set) var packetBuffer = Data()
 
 	/// The number of bytes remaining to be read for the current packet.
@@ -188,15 +187,15 @@ class ServerTunnel: Tunnel, TunnelDelegate, StreamDelegate {
     
     /// Handle a stream event.
     func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
-        simpleTunnelLog("server stream deelgate called: \(eventCode)")
-        switch aStream {
-            
-        case writeStream!:
+        simpleTunnelLog("server stream deelgate called: \(eventCode.rawValue.description)")
+        
+        /// write stream
+        if let writeStream, aStream === writeStream {
             switch eventCode {
             case [.hasSpaceAvailable]:
                 // Send any buffered data.
                 if !savedData.isEmpty {
-                    guard savedData.writeToStream(writeStream!) else {
+                    guard savedData.writeToStream(writeStream) else {
                         closeTunnel()
                         delegate?.tunnelDidClose(self)
                         break
@@ -216,8 +215,11 @@ class ServerTunnel: Tunnel, TunnelDelegate, StreamDelegate {
             default:
                 break
             }
-            
-        case readStream!:
+            return
+        }
+       
+        /// read stream
+        if let readStream, aStream === readStream {
             var needCloseTunnel = false
             switch eventCode {
             case [.hasBytesAvailable]:
@@ -237,11 +239,7 @@ class ServerTunnel: Tunnel, TunnelDelegate, StreamDelegate {
                 closeTunnel()
                 delegate?.tunnelDidClose(self)
             }
-            
-        default:
-            break
         }
-        
     }
     
     // MARK: Tunnel

--- a/tunnel_server1/ServerTunnelConnection.swift
+++ b/tunnel_server1/ServerTunnelConnection.swift
@@ -21,7 +21,11 @@ class ServerTunnelConnection: Connection {
 	var utunName: String?
 
 	/// A dispatch source for the UTUN interface socket.
-	var utunSource: DispatchSourceRead?
+    var utunSource: DispatchSourceRead? {
+        didSet {
+            simpleTunnelLog("dispatch: \(String(describing: utunSource))")
+        }
+    }
 
 	/// A flag indicating if reads from the UTUN interface are suspended.
 	var isSuspended = false
@@ -247,7 +251,7 @@ class ServerTunnelConnection: Connection {
 	/// Stop reading packets from the UTUN interface.
 	override func suspend() {
 		isSuspended = true
-        utunSource?.cancel()
+        utunSource?.suspend()
 	}
 
 	/// Resume reading packets from the UTUN interface.


### PR DESCRIPTION
If cancel() is called, calling resume() later on will result in a crash. 
If you intend suspension, then "suspend()" should be called. 